### PR TITLE
Support Firefox OS detection

### DIFF
--- a/flask_mobility/main.py
+++ b/flask_mobility/main.py
@@ -13,7 +13,7 @@ class Mobility(object):
     def init_app(self, app):
         self.app = app
         app.config.setdefault('MOBILE_USER_AGENTS',
-            'android|fennec|iemobile|iphone|opera (?:mini|mobi)')
+            'android|fennec|iemobile|iphone|opera (?:mini|mobi)|mobile')
         app.config.setdefault('MOBILE_COOKIE', 'mobile')
 
         self.USER_AGENTS = re.compile(app.config.get('MOBILE_USER_AGENTS'))


### PR DESCRIPTION
The current user agent regex doesn't match Firefox OS user agents. For reference, a Firefox OS user agent looks like: `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`. Looking for the string "Mobile" catches this.
