### PR TITLE
corrected docs to import mobile_template from decorators

### DIFF
--- a/docs/example/example.py
+++ b/docs/example/example.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from flask import Flask, render_template
-from flask.ext.mobility import Mobility, mobile_template
+from flask.ext.mobility import Mobility
+from flask.ext.mobility.decorators import mobile_template
+
 
 app = Flask(__name__)
 Mobility(app)


### PR DESCRIPTION
Simple corrected doc example to import `mobile_template` from ` flask.ext.mobility.decorators` instead of `flask.ext.mobility`