### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
     steps:
       - checkout
@@ -27,7 +27,7 @@ jobs:
           command: therapist run --use-tracked-files
   test: &test-defaults
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
     steps:
       - checkout
@@ -68,9 +68,14 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
+  test-py38:
+    <<: *test-defaults
+    docker:
+      - image: circleci/python:3.8
+
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
     steps:
       - checkout
@@ -137,12 +142,17 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - test-py38:
+          filters:
+            tags:
+              only: /^v.*/
       - deploy:
           requires:
             - lint
             - test-py35
             - test-py36
             - test-py37
+            - test-py38
           filters:
             branches:
               ignore: /.*/

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],


### PR DESCRIPTION
We need to use Flask-Mobility package on Python 3.8 but it's currently not supported. I ran the unit tests using Python 3.8 and it's working fine. 