### PR TITLE
Remove .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python:
- - "2.6"
- - "2.7"
- - "3.3"
- - "3.4"
-install: pip install -r requirements.txt --use-mirrors
-script: python setup.py test


### PR DESCRIPTION
This PR addresses #43 issue. 

As this repo now uses Circle CI, we don't need `.travis.yml` file.