### PR TITLE
Fix flask.request.MOBILE regex match bug

### DIFF
--- a/flask_mobility/mobility.py
+++ b/flask_mobility/mobility.py
@@ -26,4 +26,4 @@ class Mobility(object):
         ua = request.user_agent.string.lower()
         mc = request.cookies.get(app.config.get("MOBILE_COOKIE"))
 
-        request.MOBILE = mc == "on" or (mc != "off" and self.USER_AGENTS.search(ua))
+        request.MOBILE = mc == "on" or (mc != "off" and self.USER_AGENTS.search(ua) is not None)

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flask import Flask, render_template_string
+from flask import Flask, render_template_string, request
 from flask_mobility import Mobility
 
 
@@ -12,11 +12,11 @@ class MobilityTestCase(object):
 
         @app.route("/")
         def index():
+            assert isinstance(request.MOBILE, bool)
             tpl = "{% if request.MOBILE %}True{% else %}False{% endif %}"
             return render_template_string(tpl)
 
         return app
-        self.config = app.config
 
     def test_detect_mobile_user_agent(self, app):
         """Check that mobile user agents are properly detected"""


### PR DESCRIPTION
This PR fixes this bug: https://github.com/rehandalal/flask-mobility/issues/24

I can confirm that we have a bug in regex search:

```python
request.MOBILE = mc == "on" or (mc != "off" and self.USER_AGENTS.search(ua))
```

Here is what the documentation say:

> The `re.search()` method takes a regular expression pattern and a string and searches for that pattern within the string. If the search is successful, `search()` returns a `Match` object or `None` otherwise.

So let's say we have a match in regex the condition will become: 

```python
request.MOBILE = False or (True and re.Match())  # evaluates to: re.Match() (instead of True)
```

And let's say we do not have a match in regex the condition will become:

```python
request.MOBILE = False or (True and None)  # evaluates to: None (instead of False)
```